### PR TITLE
feat: Add new Lovense Hush Device Name/Service

### DIFF
--- a/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
+++ b/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Buttplug.Core;
-using Buttplug.Server;
 using Buttplug.Server.Bluetooth.Devices;
 using JetBrains.Annotations;
 
@@ -26,6 +25,7 @@ namespace Buttplug.Server.Bluetooth
                 new LovenseRev2BluetoothInfo(),
                 new LovenseRev3BluetoothInfo(),
                 new LovenseRev4BluetoothInfo(),
+                new LovenseRev5BluetoothInfo(),
                 new MagicMotionBluetoothInfo(),
                 new VibratissimoBluetoothInfo(),
                 new VorzeA10CycloneInfo(),

--- a/Buttplug.Server/Bluetooth/Devices/Lovense.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Lovense.cs
@@ -144,6 +144,39 @@ namespace Buttplug.Server.Bluetooth.Devices
             return new Lovense(aLogManager, aInterface, this);
         }
     }
+
+    internal class LovenseRev5BluetoothInfo : IBluetoothDeviceInfo
+    {
+        public enum Chrs : uint
+        {
+            Tx = 0,
+            Rx,
+        }
+
+        public Guid[] Services { get; } = { new Guid("5a300001-0024-4bd4-bbd5-a6920e4c5653") };
+
+        public string[] Names { get; } =
+        {
+            // Edge
+            "LVS-Domi37",
+        };
+
+        public Guid[] Characteristics { get; } =
+        {
+            // tx characteristic
+            new Guid("5a300002-0024-4bd4-bbd5-a6920e4c5653"),
+
+            // rx characteristic
+            new Guid("5a300003-0024-4bd4-bbd5-a6920e4c5653"),
+        };
+
+        public IButtplugDevice CreateDevice(IButtplugLogManager aLogManager,
+            IBluetoothDeviceInterface aInterface)
+        {
+            return new Lovense(aLogManager, aInterface, this);
+        }
+    }
+
     internal class Lovense : ButtplugBluetoothDevice
     {
         private static Dictionary<string, string> FriendlyNames = new Dictionary<string, string>()
@@ -155,6 +188,7 @@ namespace Buttplug.Server.Bluetooth.Devices
             { "LVS-S001", "Lush" },
             { "LVS-Z001", "Hush" },
             { "LVS-P36", "Edge" },
+            { "LVS-Z36", "Hush" },
             { "LVS-Domi37", "Domi" },
         };
 


### PR DESCRIPTION
Looks like Lovense is updating the Hush to run their new firmware, and
with that also changed the product name and service IDs.

Fixes #257